### PR TITLE
Add simple frame rate and prevent flickering

### DIFF
--- a/example1.cpp
+++ b/example1.cpp
@@ -402,6 +402,36 @@ private:
     int mCurrentImage;
 };
 
+
+class Fps
+{
+public:
+  explicit Fps(int tickInterval = 30)
+      : m_tickInterval(tickInterval)
+      , m_nextTime(SDL_GetTicks() + tickInterval)
+  {
+  }
+
+  void next()
+  {
+    SDL_Delay(getTicksToNextFrame());
+
+    m_nextTime += m_tickInterval;
+  }
+
+private:
+  const int m_tickInterval;
+  Uint32 m_nextTime;
+
+  Uint32 getTicksToNextFrame() const
+  {
+    Uint32 now = SDL_GetTicks();
+
+    return (m_nextTime <= now) ? 0 : m_nextTime - now;
+  }
+};
+
+
 int main(int /* argc */, char ** /* argv */)
 {
     char rendername[256] = {0};
@@ -453,6 +483,8 @@ int main(int /* argc */, char ** /* argv */)
 
     TestWindow *screen = new TestWindow(window, winWidth, winHeight);
 
+    Fps fps;
+
     bool quit = false;
     try
     {
@@ -477,6 +509,8 @@ int main(int /* argc */, char ** /* argv */)
 
             // Render the rect to the screen
             SDL_RenderPresent(renderer);
+
+            fps.next();
         }
     }
     catch (const std::runtime_error &e)

--- a/sdlgui/button.cpp
+++ b/sdlgui/button.cpp
@@ -270,6 +270,8 @@ void Button::drawBody(SDL_Renderer* renderer)
     AsyncTexturePtr newtx = std::make_shared<AsyncTexture>(id);
     newtx->load(this);
     _txs.push_back(newtx);
+
+    drawBodyTemp(renderer);
   }
 }
 

--- a/sdlgui/window.cpp
+++ b/sdlgui/window.cpp
@@ -260,8 +260,9 @@ void Window::drawBody(SDL_Renderer* renderer)
     AsyncTexturePtr newtx = std::make_shared<AsyncTexture>(id);
     newtx->load(this, 0, 0, mMouseFocus);
     _txs.push_back(newtx);
-  }
 
+    drawBodyTemp(renderer);
+  }
 }
 
 void Window::draw(SDL_Renderer* renderer)
@@ -302,7 +303,7 @@ void Window::center()
 bool Window::mouseDragEvent(const Vector2i &, const Vector2i &rel,
                             int button, int /* modifiers */) 
 {
-    if (mDrag && (button & (1 << SDL_BUTTON_LEFT)) != 0) 
+    if (mDrag && (button & (1 << SDL_BUTTON_LEFT)) != 0)
     {
         _pos += rel;
         _pos = _pos.cmax({ 0, 0 });


### PR DESCRIPTION
Adding simple "FPS" cause flickering because textures are loaded in background.
`drawBodyTemp` was used to solve this issue. 