### PR TITLE
Fix indices of DropDownBox::setSelectedIndex

### DIFF
--- a/sdlgui/dropdownbox.cpp
+++ b/sdlgui/dropdownbox.cpp
@@ -296,15 +296,21 @@ void DropdownBox::performLayout(SDL_Renderer *renderer)
   }
 }
 
-void DropdownBox::setSelectedIndex(int idx) {
+void DropdownBox::setSelectedIndex(int idx)
+{
     if (mItemsShort.empty())
         return;
+
+    const std::vector<Widget *> &children = popup().children();
+    ((Button *) children[mSelectedIndex + 1])->setPushed(false);
+    ((Button *) children[idx + 1])->setPushed(true);
     mSelectedIndex = idx;
     setCaption(mItemsShort[idx]);
     ((DropdownPopup*)mPopup)->updateCaption(mItemsShort[idx]);
 }
 
-void DropdownBox::setItems(const std::vector<std::string> &items, const std::vector<std::string> &itemsShort) {
+void DropdownBox::setItems(const std::vector<std::string> &items, const std::vector<std::string> &itemsShort)
+{
     assert(items.size() == itemsShort.size());
     mItems = items;
     mItemsShort = itemsShort;


### PR DESCRIPTION
Fix indices of DropDownBox::setSelectedIndex.
There is additional zero child which is shown on top of the button. This item contains caption of selected item...

So  popup().children() returns array of:
0. header item (show caption of selected option)
1. option 0
2. option 1
etc.

that is why +1 is required