### PR TITLE
Add a "draggable" flag to Window

### DIFF
--- a/sdlgui/window.cpp
+++ b/sdlgui/window.cpp
@@ -307,6 +307,10 @@ void Window::center()
 bool Window::mouseDragEvent(const Vector2i &, const Vector2i &rel,
                             int button, int /* modifiers */) 
 {
+    if (!mDraggable)
+    {
+        return false;
+    }
     if (mDrag && (button & (1 << SDL_BUTTON_LEFT)) != 0)
     {
         _pos += rel;

--- a/sdlgui/window.h
+++ b/sdlgui/window.h
@@ -39,6 +39,11 @@ public:
     /// Set whether or not this is a modal dialog
     void setModal(bool modal) { mModal = modal; }
 
+    /// Is this draggable?
+    bool draggable() const { return mDraggable; }
+    /// Set whether or not this is draggable
+    void setDraggable(bool draggable) { mDraggable = draggable; }
+
     /// Return the panel used to house window buttons
     Widget *buttonPanel();
 
@@ -79,6 +84,7 @@ protected:
 
     bool mModal;
     bool mDrag;
+    bool mDraggable = true;
 
     struct AsyncTexture;
     typedef std::shared_ptr<AsyncTexture> AsyncTexturePtr;


### PR DESCRIPTION
Hi, thanks for this excellent software! I'm working on a project using this, and I'm in need of a Window that can't be dragged (it's more of a toolbar than a window). This simple patch adds a flag that, if set to false, makes a Window fixed in position.