### PR TITLE
Allow disabling drop shadow for specific windows

### DIFF
--- a/sdlgui/window.cpp
+++ b/sdlgui/window.cpp
@@ -70,20 +70,22 @@ struct Window::AsyncTexture
 
 
       /* Draw a drop shadow */
-      NVGpaint shadowPaint = nvgBoxGradient(
-        ctx, mPos.x, mPos.y, ww, hh, cr * 2, ds * 2,
-        mTheme->mDropShadow.toNvgColor(), 
-        mTheme->mTransparent.toNvgColor());
+      if (wnd->dropShadowEnabled()) {
+        NVGpaint shadowPaint = nvgBoxGradient(
+          ctx, mPos.x, mPos.y, ww, hh, cr * 2, ds * 2,
+          mTheme->mDropShadow.toNvgColor(), 
+          mTheme->mTransparent.toNvgColor());
 
-      nvgSave(ctx);
-      nvgResetScissor(ctx);
-      nvgBeginPath(ctx);
-      nvgRect(ctx, mPos.x - ds, mPos.y - ds, ww + 2 * ds, hh + 2 * ds);
-      nvgRoundedRect(ctx, mPos.x, mPos.y, ww, hh, cr);
-      nvgPathWinding(ctx, NVG_HOLE);
-      nvgFillPaint(ctx, shadowPaint);
-      nvgFill(ctx);
-      nvgRestore(ctx);
+        nvgSave(ctx);
+        nvgResetScissor(ctx);
+        nvgBeginPath(ctx);
+        nvgRect(ctx, mPos.x - ds, mPos.y - ds, ww + 2 * ds, hh + 2 * ds);
+        nvgRoundedRect(ctx, mPos.x, mPos.y, ww, hh, cr);
+        nvgPathWinding(ctx, NVG_HOLE);
+        nvgFillPaint(ctx, shadowPaint);
+        nvgFill(ctx);
+        nvgRestore(ctx);
+      }
 
       /* Draw header */
       NVGpaint headerPaint = nvgLinearGradient(

--- a/sdlgui/window.h
+++ b/sdlgui/window.h
@@ -44,6 +44,11 @@ public:
     /// Set whether or not this is draggable
     void setDraggable(bool draggable) { mDraggable = draggable; }
 
+    /// Drop shadow enabled?
+    bool dropShadowEnabled() const { return mDropShadowEnabled; }
+    /// Set whether or not drop shadow is enabled
+    void setDropShadowEnabled(bool dropShadowEnabled) { mDropShadowEnabled = dropShadowEnabled; }
+
     /// Return the panel used to house window buttons
     Widget *buttonPanel();
 
@@ -85,6 +90,7 @@ protected:
     bool mModal;
     bool mDrag;
     bool mDraggable = true;
+    bool mDropShadowEnabled = true;
 
     struct AsyncTexture;
     typedef std::shared_ptr<AsyncTexture> AsyncTexturePtr;


### PR DESCRIPTION
This adds a `dropShadowEnabled` flag to Window so the shadow can be turned off for specific windows.