### PR TITLE
Clamp popups so they don't fall off the bottom of the screen

### DIFF
--- a/sdlgui/dropdownbox.cpp
+++ b/sdlgui/dropdownbox.cpp
@@ -149,7 +149,15 @@ public:
   {
     Popup::refreshRelativePlacement();
     mVisible &= mParentWindow->visibleRecursive();
+
+    Widget *widget = this;
+    while (widget->parent() != nullptr)
+      widget = widget->parent();
+    Screen *screen = (Screen *)widget;
+    Vector2i screenSize = screen->size();
+
     _pos = mParentWindow->position() + mAnchorPos;
+    _pos = Vector2i(_pos.x, std::min(_pos.y, screen->size().y - mSize.y));
   }
 
   void updateCaption(const std::string& caption)

--- a/sdlgui/popup.cpp
+++ b/sdlgui/popup.cpp
@@ -138,7 +138,15 @@ void Popup::refreshRelativePlacement()
 {
     mParentWindow->refreshRelativePlacement();
     mVisible &= mParentWindow->visibleRecursive();
+
+    Widget *widget = this;
+    while (widget->parent() != nullptr)
+        widget = widget->parent();
+    Screen *screen = (Screen *)widget;
+    Vector2i screenSize = screen->size();
+
     _pos = mParentWindow->position() + mAnchorPos - Vector2i(0, mAnchorHeight);
+    _pos = Vector2i(_pos.x, std::min(_pos.y, screen->size().y - mSize.y));
 }
 
 void Popup::drawBodyTemp(SDL_Renderer* renderer)

--- a/sdlgui/popup.h
+++ b/sdlgui/popup.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <sdlgui/window.h>
+#include <sdlgui/screen.h>
 #include <vector>
 
 NAMESPACE_BEGIN(sdlgui)


### PR DESCRIPTION
Popups, when their PopupButton is too low, can fall outside of the screen and render certain UI elements inaccessible. This PR clamps the position of popups so they stay on-screen.

![Untitled](https://user-images.githubusercontent.com/1211064/129668113-8f2b76f2-6863-4cde-8d1e-37bc7e3d743d.png)

Note that the position of the anchor is incorrect in this case. This is hard to fix as the entire popup's texture is baked in, but I hope to address it in a future PR.