### PR TITLE
Fix flickering when next Texture was requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /.directory
 /build/*
 /SDL2*
+
+#
+# IDE
+#
+.idea

--- a/sdlgui/button.h
+++ b/sdlgui/button.h
@@ -115,6 +115,11 @@ protected:
     struct AsyncTexture;
     typedef std::shared_ptr<AsyncTexture> AsyncTexturePtr;
     std::vector<AsyncTexturePtr> _txs;
+
+    AsyncTexturePtr current_texture_ = nullptr;
+
+private:
+    void drawTexture(AsyncTexturePtr& texture, SDL_Renderer* renderer);
 };
 
 NAMESPACE_END(sdlgui)

--- a/sdlgui/window.h
+++ b/sdlgui/window.h
@@ -95,6 +95,11 @@ protected:
     struct AsyncTexture;
     typedef std::shared_ptr<AsyncTexture> AsyncTexturePtr;
     std::vector<AsyncTexturePtr> _txs;
+
+    AsyncTexturePtr current_texture_ = nullptr;
+
+private:
+    void drawTexture(AsyncTexturePtr& texture, SDL_Renderer* renderer);
 };
 
 NAMESPACE_END(sdlgui)


### PR DESCRIPTION
Fix flickering for Window and Button classes (there are some other components, but their flickering is less visible and can be fixed after).

As lazy loading is used here, I suggest to use current texture until required object is ready.

Related to #55